### PR TITLE
Update map links to use consistent high-res versions

### DIFF
--- a/src/functions/map.ts
+++ b/src/functions/map.ts
@@ -1,9 +1,9 @@
 import { Bot } from '../lib/bot'
 
 const mapUrls: { [key: string]: string } = {
-  skeld: 'https://cdn.discordapp.com/attachments/771108074827808778/771213563817492510/70659-16010616511614-800.png',
-  mira: 'https://cdn.discordapp.com/attachments/771108074827808778/771213863399063552/fd819-16010617043577.png',
-  polus: 'https://cdn.discordapp.com/attachments/770436254663180321/771212583298531378/knmus9a2vgj51.png',
+  skeld: 'https://cdn.discordapp.com/attachments/420010319281127434/794073908054982696/ibx41dpjgnu51.png',
+  mira: 'https://cdn.discordapp.com/attachments/420010319281127434/794073956721098772/qezv9ppjgnu51_1.png',
+  polus: 'https://cdn.discordapp.com/attachments/420010319281127434/794073991135756329/0d6icnpjgnu51.png',
 }
 
 /**


### PR DESCRIPTION
Hey folks!

Just a quick PR to update the maps to use a set of consistent, high-res, and information dense versions:
- [Skeld Map](https://cdn.discordapp.com/attachments/420010319281127434/794073908054982696/ibx41dpjgnu51.png)
- [Mira Map](https://cdn.discordapp.com/attachments/420010319281127434/794073956721098772/qezv9ppjgnu51_1.png)
- [Polus Map](https://cdn.discordapp.com/attachments/420010319281127434/794073991135756329/0d6icnpjgnu51.png)